### PR TITLE
fix: links in nav-menu

### DIFF
--- a/christmas-shop/js/header.js
+++ b/christmas-shop/js/header.js
@@ -15,8 +15,8 @@ function HeaderAdd(){
             <nav class="nav-menu-container">
                     <ul class="nav-menu">
                         <li><a href="${path}pages/gifts.html">GIFTS</a></li>
-                        <li><a href="#about-section">ABOUT</a></li>
-                        <li><a href="#gift-section">BEST</a></li>
+                        <li><a href="${path}#about-section">ABOUT</a></li>
+                        <li><a href="${path}#gift-section">BEST</a></li>
                         <li><a href="#footer">CONTACTS</a></li>
                     </ul>
                     <div class="burger-menu">


### PR DESCRIPTION
- [x] Opening and closing burger menu on pages when the width is 768px and less.
- [x] Slider on the home page.
- [x] Timer on the home page.
- [x] Random Gifts on the home page.
- [x] Category switching for gifts on the gifts page.
- [x] Button UP on the gifts page.
- [x] Modal for the selected product on both pages.

fix links in nav-menu